### PR TITLE
Add REST API for Discord service icons and update icon handling

### DIFF
--- a/all-in-one-discord-connect-block.php
+++ b/all-in-one-discord-connect-block.php
@@ -6,7 +6,6 @@
  * Version:           1.0.0
  * Requires at least: 6.8
  * Requires PHP:      7.4
- * requires plugins:  pmpro-discord-add-on
  * Author:            Younes DRO
  * Author URI:        https://github.com/younes-dro
  * License:           GPL-2.0-or-later

--- a/includes/class-dro-aio-discord-rest-api.php
+++ b/includes/class-dro-aio-discord-rest-api.php
@@ -1,0 +1,399 @@
+<?php
+
+/**
+ * Discord REST API Handler
+ *
+ * This class handles REST API endpoints for retrieving Discord service information
+ * including service icons and other related data from active Discord add-ons.
+ *
+ * @package    Dro\AIODiscordBlock
+ * @subpackage includes
+ * @since      1.0.0
+ * @author     Younes DRO<younesdro@gmail.com>
+ */
+
+declare(strict_types=1);
+
+namespace Dro\AIODiscordBlock\includes;
+
+use Dro\AIODiscordBlock\includes\Dro_AIO_Discord_Resolver as Discord_Resolver;
+use Dro\AIODiscordBlock\includes\Interfaces\Dro_AIO_Discord_Service_Interface as Discord_Service_Interface;
+use WP_REST_Server;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_Error;
+
+// Prevent direct access
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Class Dro_AIO_Discord_Rest_Api
+ *
+ * Handles REST API endpoints for Discord service integration.
+ * Implements singleton pattern to ensure only one instance exists.
+ *
+ * @since 1.0.0
+ */
+class Dro_AIO_Discord_Rest_Api {
+
+	/**
+	 * The singleton instance of the class.
+	 *
+	 * @since 1.0.0
+	 * @var self|null
+	 */
+	protected static ?self $instance = null;
+
+	/**
+	 * API namespace for the REST routes.
+	 *
+	 * @since 1.0.0
+	 * @var string
+	 */
+	private const API_NAMESPACE = 'aio-discord/v1';
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 *
+	 * @since 1.0.0
+	 */
+	private function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Get the singleton instance of the class.
+	 *
+	 * @since 1.0.0
+	 * @return self The singleton instance
+	 */
+	public static function get_instance(): self {
+		return self::$instance ??= new self();
+	}
+
+	/**
+	 * Prevent cloning of the instance.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function __clone() {
+		$cloning_message = sprintf(
+			/* translators: %s is the class name that cannot be cloned */
+			esc_html__( 'You cannot clone instance of %s', 'dro-aio-discord-block' ),
+			get_class( $this )
+		);
+		_doing_it_wrong( __FUNCTION__, esc_html( $cloning_message ), esc_html( DRO_AIO_DISCORD_BLOCK_VERSION ) );
+	}
+
+	/**
+	 * Prevent unserializing of the instance.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function __wakeup() {
+		$unserializing_message = sprintf(
+			/* translators: %s is the class name that cannot be unserialized */
+			esc_html__( 'You cannot unserialize instance of %s', 'dro-aio-discord-block' ),
+			get_class( $this )
+		);
+		_doing_it_wrong( __FUNCTION__, esc_html( $unserializing_message ), esc_html( DRO_AIO_DISCORD_BLOCK_VERSION ) );
+	}
+
+	/**
+	 * Initialize the REST API hooks and register routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function init(): void {
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
+	}
+
+	/**
+	 * Register all REST API routes.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function register_routes(): void {
+
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/icons',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_icons' ),
+				'permission_callback' => array( $this, 'check_permissions' ),
+				'args'                => $this->get_icons_args(),
+			)
+		);
+	}
+
+	/**
+	 * Define arguments for the icons endpoint.
+	 *
+	 * @since 1.0.0
+	 * @return array
+	 */
+	private function get_icons_args(): array {
+		// No arguments needed for now - returns official icon URL directly
+		return array();
+	}
+
+	/**
+	 * Check permissions for API endpoints.
+	 *
+	 * Verifies nonce for Gutenberg block requests and ensures user has appropriate capabilities.
+	 *
+	 * @since 1.0.0
+	 * @param WP_REST_Request $request The REST request object
+	 * @return bool|WP_Error True if allowed, WP_Error if not
+	 */
+	public function check_permissions( WP_REST_Request $request ) {
+
+		if ( ! current_user_can( 'read' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You must be logged in to access this endpoint.', 'dro-aio-discord-block' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$nonce = $request->get_header( 'X-WP-Nonce' );
+
+		if ( empty( $nonce ) ) {
+
+			$nonce = $request->get_param( '_wpnonce' );
+		}
+
+		if ( empty( $nonce ) ) {
+			return new WP_Error(
+				'missing_nonce',
+				__( 'Missing security token. Please refresh the page and try again.', 'dro-aio-discord-block' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( ! wp_verify_nonce( $nonce, 'wp_rest' ) ) {
+			return new WP_Error(
+				'invalid_nonce',
+				__( 'Invalid security token. Please refresh the page and try again.', 'dro-aio-discord-block' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( current_user_can( 'edit_posts' ) || current_user_can( 'edit_pages' ) ) {
+			return true;
+		}
+
+		// For non-admin users, ensure they can at least read
+		if ( current_user_can( 'read' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'insufficient_permissions',
+			__( 'You do not have sufficient permissions to access this endpoint.', 'dro-aio-discord-block' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
+	 * Get Discord service icons.
+	 *
+	 * Returns the official icon URL from the WordPress plugin repository.
+	 * Endpoint: GET /wp-json/aio-discord/v1/icons
+	 *
+	 * @since 1.0.0
+	 * @param WP_REST_Request $request The REST request object
+	 * @return WP_REST_Response|WP_Error Response object or WP_Error on failure
+	 */
+	public function get_icons( WP_REST_Request $request ) {
+		try {
+			$active_service = Discord_Resolver::get_active_service();
+
+			if ( ! $active_service instanceof Discord_Service_Interface ) {
+				return new WP_Error(
+					'no_active_service',
+					__( 'No active Discord service found.', 'dro-aio-discord-block' ),
+					array( 'status' => 404 )
+				);
+			}
+			$service_icon = $active_service->get_service_icon_url();
+
+			if ( empty( $service_icon ) ) {
+				return new WP_Error(
+					'no_icon_available',
+					__( 'No icon available for the active service.', 'dro-aio-discord-block' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			if ( ! filter_var( $service_icon, FILTER_VALIDATE_URL ) ) {
+				return new WP_Error(
+					'invalid_icon_url',
+					__( 'Invalid icon URL returned from service.', 'dro-aio-discord-block' ),
+					array( 'status' => 500 )
+				);
+			}
+
+			$response_data = array(
+				'success'    => true,
+				'data'       => array(
+					'icon_url'     => esc_url( $service_icon ),
+					'service_name' => method_exists( $active_service, 'get_service_name' )
+									? $active_service->get_service_name()
+									: 'Discord Service',
+					'is_official'  => true,
+				),
+				'timestamp'  => time(),
+				'cache_time' => 3600,
+			);
+
+			$response = new WP_REST_Response( $response_data, 200 );
+
+			$response->header( 'Cache-Control', 'public, max-age=3600' );
+
+			return $response;
+
+		} catch ( Exception $e ) {
+			// Log error for debugging
+			error_log( 'Discord REST API Error: ' . $e->getMessage() );
+
+			return new WP_Error(
+				'internal_error',
+				__( 'An internal error occurred while fetching the icon.', 'dro-aio-discord-block' ),
+				array( 'status' => 500 )
+			);
+		}
+	}
+
+	/**
+	 * Get comprehensive service information.
+	 *
+	 * Endpoint: GET /wp-json/aio-discord/v1/service-info
+	 *
+	 * @since 1.0.0
+	 * @param WP_REST_Request $request The REST request object
+	 * @return WP_REST_Response|WP_Error Response object or WP_Error on failure
+	 */
+	public function get_service_info( WP_REST_Request $request ) {
+		try {
+			$active_service = Discord_Resolver::get_active_service();
+			if ( ! $active_service instanceof Discord_Service_Interface ) {
+				return new WP_Error(
+					'no_active_service',
+					__( 'No active Discord service found.', 'dro-aio-discord-block' ),
+					array( 'status' => 404 )
+				);
+			}
+
+			$service_info = array(
+				'service_name' => method_exists( $active_service, 'get_service_name' )
+								? $active_service->get_service_name()
+								: 'Discord Service',
+				'icon_url'     => esc_url( $active_service->get_service_icon_url() ),
+				'is_active'    => true,
+				'version'      => method_exists( $active_service, 'get_version' )
+								? $active_service->get_version()
+								: '1.0.0',
+			);
+
+			if ( method_exists( $active_service, 'get_service_description' ) ) {
+				$service_info['description'] = $active_service->get_service_description();
+			}
+
+			if ( method_exists( $active_service, 'get_service_status' ) ) {
+				$service_info['status'] = $active_service->get_service_status();
+			}
+
+			$response_data = array(
+				'success'   => true,
+				'data'      => $service_info,
+				'timestamp' => time(),
+			);
+
+			return new WP_REST_Response( $response_data, 200 );
+
+		} catch ( Exception $e ) {
+			error_log( 'Discord Service Info Error: ' . $e->getMessage() );
+
+			return new WP_Error(
+				'internal_error',
+				__( 'An internal error occurred while fetching service information.', 'dro-aio-discord-block' ),
+				array( 'status' => 500 )
+			);
+		}
+	}
+
+
+	/**
+	 * Get the API namespace.
+	 *
+	 * @since 1.0.0
+	 * @return string The API namespace
+	 */
+	public function get_api_namespace(): string {
+		return self::API_NAMESPACE;
+	}
+
+	/**
+	 * Check if the service is available.
+	 *
+	 * @since 1.0.0
+	 * @return bool True if service is available, false otherwise
+	 */
+	public function is_service_available(): bool {
+		try {
+			$active_service = Discord_Resolver::get_active_service();
+			return $active_service instanceof Discord_Service_Interface;
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Enqueue assets for Gutenberg block editor.
+	 *
+	 * Provides REST API endpoints and nonce for secure requests from Gutenberg blocks.
+	 *
+	 * @since 1.0.0
+	 * @return void
+	 */
+	public function enqueue_block_editor_assets(): void {
+		// Localize script data for Gutenberg blocks
+		wp_localize_script(
+			'wp-api-fetch', // WordPress core script that handles REST API requests
+			'droDiscordApi',
+			array(
+				'apiUrl'    => rest_url( self::API_NAMESPACE ),
+				'nonce'     => wp_create_nonce( 'wp_rest' ),
+				'endpoints' => array(
+					'icons'       => rest_url( self::API_NAMESPACE . '/icons' ),
+					'serviceInfo' => rest_url( self::API_NAMESPACE . '/service-info' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get REST API endpoints for external use.
+	 *
+	 * Useful for providing endpoint URLs to JavaScript or other integrations.
+	 *
+	 * @since 1.0.0
+	 * @return array Array of endpoint URLs
+	 */
+	public function get_endpoints(): array {
+		return array(
+			'icons'       => rest_url( self::API_NAMESPACE . '/icons' ),
+			'serviceInfo' => rest_url( self::API_NAMESPACE . '/service-info' ),
+		);
+	}
+}

--- a/includes/class-dro-aio-discord.php
+++ b/includes/class-dro-aio-discord.php
@@ -40,6 +40,13 @@ class Dro_AIO_Discord {
 		add_action( 'plugins_loaded', array( $this, 'plugin_loaded' ) );
 		add_action( 'init', array( $this, 'init' ) );
 	}
+	/**
+	 * Trigger the plugin_loaded action.
+	 * Resolves the active Discord service.
+	 * Initializes the Discord REST API.
+	 *
+	 * @return void
+	 */
 	public function plugin_loaded() {
 		Discord_Resolver::resolve();
 		Discord_Rest_Api::get_instance();
@@ -58,8 +65,14 @@ class Dro_AIO_Discord {
 	 *
 	 * @return void
 	 */
-	private function __clone() {
-		// Prevent cloning of the instance.
+	public function __clone() {
+
+		$cloning_message = sprintf(
+			/* translators: %s is the class name that cannot be cloned */
+			esc_html__( 'You cannot clone instance of %s', 'dro-aio-discord-block' ),
+			get_class( $this )
+		);
+		_doing_it_wrong( __FUNCTION__, esc_html( $cloning_message ), esc_html( DRO_AIO_DISCORD_BLOCK_VERSION ) );
 	}
 	/**
 	 * Prevent unserializing of the instance.

--- a/includes/class-dro-aio-discord.php
+++ b/includes/class-dro-aio-discord.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Dro\AIODiscordBlock\includes;
 
 use Dro\AIODiscordBlock\includes\Dro_AIO_Discord_Resolver as Discord_Resolver;
+use Dro\AIODiscordBlock\includes\Dro_AIO_Discord_Rest_Api as Discord_Rest_Api;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
@@ -41,6 +42,7 @@ class Dro_AIO_Discord {
 	}
 	public function plugin_loaded() {
 		Discord_Resolver::resolve();
+		Discord_Rest_Api::get_instance();
 	}
 	/**
 	 * Get the instance of the class.

--- a/includes/interfaces/class-dro-aio-discord-service-interface.php
+++ b/includes/interfaces/class-dro-aio-discord-service-interface.php
@@ -106,9 +106,9 @@ interface Dro_AIO_Discord_Service_Interface {
 	/**
 	 * Get the Add-On icon URL.
 	 *
-	 * @return string The URL of the service icon.
+	 * @return string TheURL of the service icon.
 	 */
-	public function get_service_base64_encode_icon(): string;
+	public function get_service_icon_url(): string;
 
 	/**
 	 * Initializes the Discord user data for the given user ID.

--- a/includes/services/class-dro-aio-discord-memberpress.php
+++ b/includes/services/class-dro-aio-discord-memberpress.php
@@ -110,13 +110,16 @@ class Dro_AIO_Discord_MemberPress extends Dro_AIO_Discord_Service implements Dro
 	}
 
 	/**
-	 * Get base64-encoded icon string.
+	 * Geticon string.
 	 *
 	 * @return string
 	 */
-	public function get_service_base64_encode_icon(): string {
-		// TODO: Provide base64 image for MemberPress branding.
-		return '';
+	public function get_service_icon_url(): string {
+
+		return 'https://ps.w.org/expresstechsoftwares-memberpress-discord-add-on/assets/icon-256x256.gif';
+	}
+
+	public function load_discord_user_data( int $user_id ): void {
 	}
 
 	public function build_html_block( array $attributes, string $content, \WP_Block $block ): string {

--- a/includes/services/class-dro-aio-discord-pmpro.php
+++ b/includes/services/class-dro-aio-discord-pmpro.php
@@ -197,6 +197,7 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 		if ( Check_saved_settings_status() && $access_token ) {
 
 			$html .= $this->get_disconnect_button(
+				$user_id,
 				$disconnect_button_bg_color,
 				$disconnect_button_text_color,
 				$logged_out_text
@@ -218,30 +219,58 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 
 		return $html;
 	}
-
+	/**
+	 * Generates the HTML markup for the Discord connect button.
+	 *
+	 * @since 1.0.0
+	 * @access private
+	 *
+	 * @param string $button_bg_color   Background color for the button.
+	 * @param string $button_text_color Text color for the button.
+	 * @param string $button_text       Text displayed on the button.
+	 *
+	 * @return string HTML markup for the connect button.
+	 */
 	private function get_connect_button( string $button_bg_color, string $button_text_color, string $button_text ): string {
-
 		$button_html  = '';
 		$current_url  = ets_pmpro_discord_get_current_screen_url();
 		$button_html .= '<a href="?action=discord-login&url=' . $current_url . '"
-		class="dro-aio-discord-connect-button"
-		style="background-color:' . esc_attr( $button_bg_color ) . '; color:' . esc_attr( $button_text_color ) . ';">'
+        class="dro-aio-discord-connect-button"
+        style="background-color:' . esc_attr( $button_bg_color ) . '; color:' . esc_attr( $button_text_color ) . ';">'
 		. esc_html( $button_text )
 		. '<i class="fab fa-discord"></i></a>';
 
 		return $button_html;
 	}
-	private function get_disconnect_button( string $button_bg_color, string $button_text_color, string $button_text ): string {
 
+	/**
+	 * Generates the HTML markup for the Discord disconnect button.
+	 *
+	 * @since 1.0.0
+	 * @access private
+	 *
+	 * @param int    $user_id           ID of the user to disconnect.
+	 * @param string $button_bg_color   Background color for the button.
+	 * @param string $button_text_color Text color for the button.
+	 * @param string $button_text       Text displayed on the button.
+	 *
+	 * @return string HTML markup for the disconnect button.
+	 */
+	private function get_disconnect_button( int $user_id, string $button_bg_color, string $button_text_color, string $button_text ): string {
+		wp_enqueue_script( 'ets_pmpro_add_discord_script' );
+		wp_enqueue_style( 'ets_pmpro_add_discord_style' );
 		$button_html  = '';
 		$button_html .= '<a href="?action=discord-logout"
-		 class="dro-aio-discord-disconnect-button"
-		 style="background-color:' . esc_attr( $button_bg_color ) . '; color:' . esc_attr( $button_text_color ) . ';">'
+         class="dro-aio-discord-disconnect-button"
+         id="pmpro-disconnect-discord"
+         data-user-id="' . $user_id . '"
+         style="background-color:' . esc_attr( $button_bg_color ) . '; color:' . esc_attr( $button_text_color ) . ';">'
 			. esc_html__( $button_text )
 			. '<i class="fab fa-discord"></i></a>';
 
-		return $button_html;
+		return $button_html . '<span class="ets-spinner"></span>';
 	}
+
 
 
 	/**

--- a/includes/services/class-dro-aio-discord-pmpro.php
+++ b/includes/services/class-dro-aio-discord-pmpro.php
@@ -147,13 +147,13 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 	}
 
 	/**
-	 * Get the base64 encoded icon for the PMPro Discord service.
+	 * Get the icon for the PMPro Discord service.
 	 *
-	 * @return string Base64 encoded icon string.
+	 * @return string icon url.
 	 */
-	public function get_service_base64_encode_icon(): string {
-		// TODO: Implement logic to return the base64 encoded icon.
-		return '';
+	public function get_service_icon_url(): string {
+
+		return 'https://ps.w.org/pmpro-discord-add-on/assets/icon-256x256.png';
 	}
 
 	/**
@@ -189,7 +189,6 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 			);
 			$html .= $this->get_user_infos( $discord_connected_account_text, $user_id );
 			$html .= $this->get_user_roles( $role_assigned_text, $user_id );
-
 
 		} elseif ( pmpro_hasMembershipLevel() || $allow_none_member == 'yes' ) {
 

--- a/includes/services/class-dro-aio-discord-pmpro.php
+++ b/includes/services/class-dro-aio-discord-pmpro.php
@@ -55,7 +55,14 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 	 */
 	private const PLUGIN_NAME = 'pmpro-discord-add-on/pmpro-discord.php';
 
-
+	/**
+	 * The official icon URL for the service add-on.
+	 *
+	 * @since 1.0.0
+	 * @access private
+	 * @var string
+	 */
+	private const PLUGIN_ICON = 'https://ps.w.org/pmpro-discord-add-on/assets/icon-256x256.png';
 
 	/**
 	 * Get the plugin name for the PMPro Discord add-on.
@@ -78,20 +85,27 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 	}
 
 	/**
-	 * Load Discord user data for the PMPro service.
+	 * Loads Discord user data for the PMPro service.
 	 *
-	 * @param integer $user_id
+	 * Note: The PMPro Discord Add-on does not set the meta key `_ets_pmpro_discord_avatar`,
+	 * so it will typically return null. This key is retained for compatibility purposes.
+	 *
+	 * @param int $user_id The ID of the user whose Discord data should be loaded.
 	 * @return void
 	 */
 	public function load_discord_user_data( int $user_id ): void {
-		$username   = get_user_meta( $user_id, '_ets_pmpro_discord_username', true );
-		$avatar     = get_user_meta( $user_id, '_ets_pmpro_discord_avatar', true );
-		$discord_id = get_user_meta( $user_id, '_ets_pmpro_discord_user_id', true );
+		$username   = sanitize_text_field( get_user_meta( $user_id, '_ets_pmpro_discord_username', true ) );
+		$avatar     = sanitize_text_field( get_user_meta( $user_id, '_ets_pmpro_discord_avatar', true ) );
+		$discord_id = sanitize_text_field( get_user_meta( $user_id, '_ets_pmpro_discord_user_id', true ) );
 
-		$this->discord_user_name   = $username ?: null;
-		$this->discord_user_avatar = $avatar ?: null;
-		$this->discord_user_id     = $discord_id ? (int) $discord_id : null;
+		$this->set_discord_user_name( $username ?: null );
+		$this->set_discord_user_avatar( $avatar ?: null );
+
+		$this->set_discord_user_id( (int) $discord_id ?: null );
+
+		$this->discord_user_id = $discord_id ? (int) $discord_id : null;
 	}
+
 	/**
 	 * Gets the discord connected account for a user.
 	 *
@@ -153,7 +167,7 @@ class Dro_AIO_Discord_Pmpro extends Discord_Service implements Discord_Service_I
 	 */
 	public function get_service_icon_url(): string {
 
-		return 'https://ps.w.org/pmpro-discord-add-on/assets/icon-256x256.png';
+		return self::PLUGIN_ICON;
 	}
 
 	/**

--- a/includes/services/class-dro-aio-discord-tutorlms.php
+++ b/includes/services/class-dro-aio-discord-tutorlms.php
@@ -99,7 +99,7 @@ class Dro_AIO_Discord_TutorLMS extends Dro_AIO_Discord_Service implements Dro_AI
 	 *
 	 * @return string
 	 */
-	public function get_service_base64_encode_icon(): string {
+	public function get_service_icon_url(): string {
 		// TODO: Add Tutor LMS base64 icon string.
 		return '';
 	}

--- a/includes/services/class-dro-aio-discord-ultimatemember.php
+++ b/includes/services/class-dro-aio-discord-ultimatemember.php
@@ -113,7 +113,7 @@ class Dro_AIO_Discord_UltimateMember extends Dro_AIO_Discord_Service implements 
 	 *
 	 * @return string
 	 */
-	public function get_service_base64_encode_icon(): string {
+	public function get_service_icon_url(): string {
 		// TODO: Provide base64 image of Ultimate Member icon.
 		return '';
 	}

--- a/src/all-in-one-discord-connect-block/assets/CustomServiceIcon.js
+++ b/src/all-in-one-discord-connect-block/assets/CustomServiceIcon.js
@@ -1,0 +1,38 @@
+/**
+ * SVG wrapper approach - More reliable for toolbar usage
+ * This ensures consistent rendering across different contexts
+ *
+ * @param {string} iconURL - The URL of the image to use as icon
+ * @param {number} size - The size of the icon (default: 20)
+ * @returns {JSX.Element} SVG-wrapped icon
+ */
+export const ServiceIconSVG = ({ iconURL, size = 20 }) => {
+	if (!iconURL) {
+		// Fallback SVG icon
+		return (
+			<svg width={size} height={size} viewBox="0 0 24 24" fill="currentColor">
+				<circle cx="12" cy="12" r="10" />
+				<text x="12" y="16" textAnchor="middle" fontSize="12" fill="white">?</text>
+			</svg>
+		);
+	}
+
+	return (
+		<svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+			<foreignObject width="100%" height="100%">
+				<img
+					src={iconURL}
+					alt="Service Icon"
+					style={{
+						width: '100%',
+						height: '100%',
+						objectFit: 'contain'
+					}}
+				/>
+			</foreignObject>
+		</svg>
+	);
+};
+
+
+

--- a/src/all-in-one-discord-connect-block/render.php
+++ b/src/all-in-one-discord-connect-block/render.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Dro\AIODiscordBlock\includes\Dro_AIO_Discord_Render as Discord_Render;
 use Dro\AIODiscordBlock\includes\Dro_AIO_Discord_Resolver as Discord_Resolver;
-error_log( print_r( Discord_Resolver::get_active_service(), true ) );
+
 
 $user_id = get_current_user_id();
 $service = Discord_Resolver::get_active_service();

--- a/src/all-in-one-discord-connect-block/render.php
+++ b/src/all-in-one-discord-connect-block/render.php
@@ -22,7 +22,8 @@ if ( $service && $user_id ) {
 
 $render_block = '';
 try {
-	$render_block = Discord_Render::get_instance( $service )->render( $attributes, $content, $block );
+	$render_block = Discord_Render::get_instance( $service )
+					->render( $attributes, $content, $block );
 } catch ( Throwable $e ) {
 	error_log( $e->getMessage() );
 }


### PR DESCRIPTION
- Introduces a new REST API handler for retrieving Discord service icon URLs and related data.
- Refactors service interface and implementations to use get_service_icon_url instead of base64 encoding.
- Updates block editor to fetch and display service icons dynamically, and adds a new SVG icon component for consistent rendering.
- Minor code and doc improvements throughout.
#14 